### PR TITLE
修复排行榜页面 id 为 undefined 的 bug

### DIFF
--- a/src/pages/ranklist/index.js
+++ b/src/pages/ranklist/index.js
@@ -109,7 +109,7 @@ export default class Ranklist extends React.PureComponent {
                   </div>
                 ]}
               >
-                <Link to={'/user/' + item.id}>
+                <Link to={'/user/' + item.user_id}>
                   <Tag className='rank-tag' color={color.blue}>
                     {index + 1}
                   </Tag>


### PR DESCRIPTION
修复排行榜页面 id 为 undefined 的 bug

<img width="539" alt="image" src="https://github.com/ouxu/oj-pro/assets/88307754/aabb18c0-0d74-4ba8-9d9b-357f1ad60e6e">
